### PR TITLE
Fix: Resolve Google Vertex AI schema compatibility issues

### DIFF
--- a/src/etim_mcp/server.py
+++ b/src/etim_mcp/server.py
@@ -149,10 +149,10 @@ async def search_classes(
     language: str = "EN",
     max_results: int = 10,
     exclude_modelling: bool = False,
-    release_filter: Optional[list[str]] = None,
-    group_filter: Optional[list[str]] = None,
-    feature_filter: Optional[list[str]] = None,
-    value_filter: Optional[list[str]] = None,
+    release_filter: list[str] = [],
+    group_filter: list[str] = [],
+    feature_filter: list[str] = [],
+    value_filter: list[str] = [],
     ctx: Context[ServerSession, AppContext] = None,
 ) -> dict:
     """
@@ -209,7 +209,7 @@ async def search_classes(
 @mcp.tool()
 async def get_class_details(
     class_code: str,
-    version: Optional[int] = None,
+    version: int = 0,
     language: str = "EN",
     include_features: bool = True,
     max_response_tokens: int = 20000,
@@ -231,9 +231,12 @@ async def get_class_details(
     client = ctx.request_context.lifespan_context.client
 
     try:
+        # Convert 0 to None for the client (ETIM versions start at 1, not 0)
+        version_param = None if version == 0 else version
+
         result = await client.get_class_details(
             class_code=class_code,
-            version=version,
+            version=version_param,
             language=language,
             include_features=include_features
         )


### PR DESCRIPTION
## Fix Google Vertex AI Compatibility Issues

### Problem

Some MCP tools in the ETIM server use JSON schemas with `anyOf` combined with other schema properties, which causes compatibility issues with Google Vertex AI's function calling API (specifically when used as sub-agents).

**Error encountered:**
```
google.genai.errors.ClientError: 400 INVALID_ARGUMENT. 
{'error': {
  'code': 400, 
  'message': 'Unable to submit request because `search_classes` functionDeclaration `parameters.group_filter` schema specified other fields alongside any_of. When using any_of, it must be the only field set. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling', 
  'status': 'INVALID_ARGUMENT'
}}
```

### Root Cause

- `Optional[list[str]] = None` generates `anyOf: [array, null]` schemas
- `Optional[int] = None` generates `anyOf: [integer, null]` schemas  
- Vertex AI rejects schemas that combine `anyOf` with other properties

### Solution

#### 1. **search_classes** tool - Filter Parameters
Changed four filter parameters from `Optional[list[str]] = None` to `list[str] = []`:
- `release_filter`
- `group_filter`
- `feature_filter`
- `value_filter`

The existing logic checks `if filter:`, which evaluates to `False` for both `None` and `[]`, making them functionally equivalent.

#### 2. **get_class_details** tool - Version Parameter
Changed `version` parameter from `Optional[int] = None` to `int = 0` with conversion logic:
```python
# Convert 0 to None for the client (ETIM versions start at 1, not 0)
version_param = None if version == 0 else version
```